### PR TITLE
refactor: use tar instead of tar-stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,15 +43,13 @@
 		"chalk": "^4.1.0",
 		"cli-simple-table": "^1.0.0",
 		"filesize": "^6.1.0",
-		"gunzip-maybe": "^1.4.2",
 		"gzip-size": "^6.0.0",
 		"libnpmpack": "^2.0.0",
 		"meow": "^8.0.0",
-		"tar-stream": "^2.1.4"
+		"tar": "^6.0.5"
 	},
 	"devDependencies": {
-		"@types/gunzip-maybe": "^1.4.0",
-		"@types/tar-stream": "^2.1.0",
+		"@types/tar": "^4.0.4",
 		"husky": "^4.3.0",
 		"lint-staged": "^10.5.2",
 		"type-fest": "^0.20.2",

--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
 	},
 	"dependencies": {
 		"brotli-size": "^4.0.0",
+		"byte-size": "^7.0.0",
 		"chalk": "^4.1.0",
 		"cli-simple-table": "^1.0.0",
-		"filesize": "^6.1.0",
 		"gzip-size": "^6.0.0",
 		"libnpmpack": "^2.0.0",
 		"meow": "^8.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,14 +3,12 @@ dependencies:
   chalk: 4.1.0
   cli-simple-table: 1.0.0
   filesize: 6.1.0
-  gunzip-maybe: 1.4.2
   gzip-size: 6.0.0
   libnpmpack: 2.0.0
   meow: 8.0.0
-  tar-stream: 2.1.4
+  tar: 6.0.5
 devDependencies:
-  '@types/gunzip-maybe': 1.4.0
-  '@types/tar-stream': 2.1.0
+  '@types/tar': 4.0.4
   husky: 4.3.0
   lint-staged: 10.5.2
   type-fest: 0.20.2
@@ -240,12 +238,6 @@ packages:
     dev: true
     resolution:
       integrity: sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==
-  /@types/gunzip-maybe/1.4.0:
-    dependencies:
-      '@types/node': 14.14.10
-    dev: true
-    resolution:
-      integrity: sha512-dFP9GrYAR9KhsjTkWJ8q8Gsfql75YIKcg9DuQOj/IrlPzR7W+1zX+cclw1McV82UXAQ+Lpufvgk3e9bC8+HzgA==
   /@types/json-schema/7.0.6:
     dev: true
     resolution:
@@ -261,6 +253,12 @@ packages:
   /@types/minimist/1.2.1:
     resolution:
       integrity: sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==
+  /@types/minipass/2.2.0:
+    dependencies:
+      '@types/node': 14.14.10
+    dev: true
+    resolution:
+      integrity: sha512-wuzZksN4w4kyfoOv/dlpov4NOunwutLA/q7uc00xU02ZyUY+aoM5PWIXEKBMnm0NHd4a+N71BMjq+x7+2Af1fg==
   /@types/node/14.14.10:
     dev: true
     resolution:
@@ -272,12 +270,13 @@ packages:
     dev: true
     resolution:
       integrity: sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
-  /@types/tar-stream/2.1.0:
+  /@types/tar/4.0.4:
     dependencies:
+      '@types/minipass': 2.2.0
       '@types/node': 14.14.10
     dev: true
     resolution:
-      integrity: sha512-s1UQxQUVMHbSkCC0X4qdoiWgHF8DoyY1JjQouFsnk/8ysoTdBaiCHud/exoAZzKDbzAXVc+ah6sczxGVMAohFw==
+      integrity: sha512-0Xv+xcmkTsOZdIF4yCnd7RkOOyfyqPaqJ7RZFKnwdxfDbkN3eAAE9sHl8zJFqBz4VhxolW9EErbjR1oyH7jK2A==
   /@typescript-eslint/eslint-plugin/4.9.0_512ef60ad8498ffab9c030d01801a819:
     dependencies:
       '@typescript-eslint/experimental-utils': 4.9.0_eslint@7.14.0+typescript@4.1.2
@@ -693,6 +692,7 @@ packages:
     resolution:
       integrity: sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==
   /base64-js/1.5.1:
+    dev: true
     resolution:
       integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
   /bcrypt-pbkdf/1.0.2:
@@ -701,14 +701,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=
-  /bl/4.0.3:
-    dependencies:
-      buffer: 5.7.1
-      inherits: 2.0.4
-      readable-stream: 3.6.0
-    dev: false
-    resolution:
-      integrity: sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==
   /bn.js/4.11.9:
     dev: true
     resolution:
@@ -824,12 +816,6 @@ packages:
     dev: true
     resolution:
       integrity: sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==
-  /browserify-zlib/0.1.4:
-    dependencies:
-      pako: 0.2.9
-    dev: false
-    resolution:
-      integrity: sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=
   /browserify-zlib/0.2.0:
     dependencies:
       pako: 1.0.11
@@ -842,10 +828,6 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-/vKNqLgROgoNtEMLC2Rntpcws0o=
-  /buffer-from/1.1.1:
-    dev: false
-    resolution:
-      integrity: sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
   /buffer-xor/1.0.3:
     dev: true
     resolution:
@@ -858,13 +840,6 @@ packages:
     dev: true
     resolution:
       integrity: sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==
-  /buffer/5.7.1:
-    dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.2.1
-    dev: false
-    resolution:
-      integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
   /builtin-status-codes/3.0.0:
     dev: true
     resolution:
@@ -1466,15 +1441,6 @@ packages:
     dev: true
     resolution:
       integrity: sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=
-  /duplexify/3.7.1:
-    dependencies:
-      end-of-stream: 1.4.4
-      inherits: 2.0.4
-      readable-stream: 2.3.7
-      stream-shift: 1.0.1
-    dev: false
-    resolution:
-      integrity: sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==
   /ecc-jsbn/0.1.2:
     dependencies:
       jsbn: 0.1.1
@@ -1511,6 +1477,7 @@ packages:
   /end-of-stream/1.4.4:
     dependencies:
       once: 1.4.0
+    dev: true
     resolution:
       integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
   /enhance-visitors/1.0.0:
@@ -2234,10 +2201,6 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=
-  /fs-constants/1.0.0:
-    dev: false
-    resolution:
-      integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
   /fs-extra/9.0.1:
     dependencies:
       at-least-node: 1.0.0
@@ -2438,18 +2401,6 @@ packages:
   /graceful-fs/4.2.4:
     resolution:
       integrity: sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
-  /gunzip-maybe/1.4.2:
-    dependencies:
-      browserify-zlib: 0.1.4
-      is-deflate: 1.0.0
-      is-gzip: 1.0.0
-      peek-stream: 1.1.3
-      pumpify: 1.5.1
-      through2: 2.0.5
-    dev: false
-    hasBin: true
-    resolution:
-      integrity: sha512-4haO1M4mLO91PW57BMsDFf75UmwoRX0GkdD+Faw+Lr+r/OZrOCS0pIBwOL1xCKQqnQzbNFGgK2V2CpBUPeFNTw==
   /gzip-size/6.0.0:
     dependencies:
       duplexer: 0.1.2
@@ -2660,6 +2611,7 @@ packages:
     resolution:
       integrity: sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==
   /ieee754/1.2.1:
+    dev: true
     resolution:
       integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
   /ignore-walk/3.0.3:
@@ -2824,10 +2776,6 @@ packages:
       node: '>= 0.4'
     resolution:
       integrity: sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==
-  /is-deflate/1.0.0:
-    dev: false
-    resolution:
-      integrity: sha1-yGKQHDwWH7CdrHzcfnhPgOmPLxQ=
   /is-descriptor/0.1.6:
     dependencies:
       is-accessor-descriptor: 0.1.6
@@ -2914,12 +2862,6 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
-  /is-gzip/1.0.0:
-    dev: false
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-bKiwe5nHeZgCWQDlVc7Y7YCHmoM=
   /is-installed-globally/0.3.2:
     dependencies:
       global-dirs: 2.0.1
@@ -4121,10 +4063,6 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-oJ7Bg7p3izrIMhZPHCCHmMHQl+xb+pKBXL5ZYeM2oCZrw6sBRSx7f8l7F+95V2qA0BP3c1cNaaBmUNkbo6Hn9w==
-  /pako/0.2.9:
-    dev: false
-    resolution:
-      integrity: sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=
   /pako/1.0.11:
     dev: true
     resolution:
@@ -4238,14 +4176,6 @@ packages:
       node: '>=0.12'
     resolution:
       integrity: sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==
-  /peek-stream/1.1.3:
-    dependencies:
-      buffer-from: 1.1.1
-      duplexify: 3.7.1
-      through2: 2.0.5
-    dev: false
-    resolution:
-      integrity: sha512-FhJ+YbOSBb9/rIl2ZeE/QHEsWn7PqNYt8ARAY3kIgNGOk13g9FGyIY6JIl/xB/3TFRVoTv5as0l11weORrTekA==
   /performance-now/2.1.0:
     dev: false
     resolution:
@@ -4398,13 +4328,6 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-ssjRZxBd7BT3dte1RR3VoeT2cT/ODH8x+h0rUF1rMqB0srHYf48stSDWfiYakTp5UBZMxroZhB2+ExLDHm7W3g==
-  /pump/2.0.1:
-    dependencies:
-      end-of-stream: 1.4.4
-      once: 1.4.0
-    dev: false
-    resolution:
-      integrity: sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==
   /pump/3.0.0:
     dependencies:
       end-of-stream: 1.4.4
@@ -4412,14 +4335,6 @@ packages:
     dev: true
     resolution:
       integrity: sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==
-  /pumpify/1.5.1:
-    dependencies:
-      duplexify: 3.7.1
-      inherits: 2.0.4
-      pump: 2.0.1
-    dev: false
-    resolution:
-      integrity: sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==
   /punycode/1.3.2:
     dev: true
     resolution:
@@ -4548,6 +4463,7 @@ packages:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
+    dev: true
     engines:
       node: '>= 6'
     resolution:
@@ -5047,10 +4963,6 @@ packages:
     dev: true
     resolution:
       integrity: sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==
-  /stream-shift/1.0.1:
-    dev: false
-    resolution:
-      integrity: sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==
   /string-argv/0.3.1:
     dev: true
     engines:
@@ -5108,6 +5020,7 @@ packages:
   /string_decoder/1.3.0:
     dependencies:
       safe-buffer: 5.2.1
+    dev: true
     resolution:
       integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
   /stringify-object/3.3.0:
@@ -5214,18 +5127,6 @@ packages:
       node: '>=0.6'
     resolution:
       integrity: sha1-KcNXB8K3DlDQdIK10gLo7URtr9Q=
-  /tar-stream/2.1.4:
-    dependencies:
-      bl: 4.0.3
-      end-of-stream: 1.4.4
-      fs-constants: 1.0.0
-      inherits: 2.0.4
-      readable-stream: 3.6.0
-    dev: false
-    engines:
-      node: '>=6'
-    resolution:
-      integrity: sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==
   /tar/6.0.5:
     dependencies:
       chownr: 2.0.0
@@ -5253,13 +5154,6 @@ packages:
     dev: true
     resolution:
       integrity: sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
-  /through2/2.0.5:
-    dependencies:
-      readable-stream: 2.3.7
-      xtend: 4.0.2
-    dev: false
-    resolution:
-      integrity: sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==
   /timers-browserify/2.0.12:
     dependencies:
       setimmediate: 1.0.5
@@ -5715,6 +5609,7 @@ packages:
     resolution:
       integrity: sha512-0k9m8pHilTzAYqw3L7qEXxuo3X87M2pYDBSzLvFD5aIpXEydZvSHLR7xbGrXKpK+sWGi825lL7+iEC1s/XZCRQ==
   /xtend/4.0.2:
+    dev: true
     engines:
       node: '>=0.4'
     resolution:
@@ -5740,19 +5635,17 @@ packages:
     resolution:
       integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 specifiers:
-  '@types/gunzip-maybe': ^1.4.0
-  '@types/tar-stream': ^2.1.0
+  '@types/tar': ^4.0.4
   brotli-size: ^4.0.0
   chalk: ^4.1.0
   cli-simple-table: ^1.0.0
   filesize: ^6.1.0
-  gunzip-maybe: ^1.4.2
   gzip-size: ^6.0.0
   husky: ^4.3.0
   libnpmpack: ^2.0.0
   lint-staged: ^10.5.2
   meow: ^8.0.0
-  tar-stream: ^2.1.4
+  tar: ^6.0.5
   type-fest: ^0.20.2
   typescript: ^4.1.2
   xo: ^0.35.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,8 +1,8 @@
 dependencies:
   brotli-size: 4.0.0
+  byte-size: 7.0.0
   chalk: 4.1.0
   cli-simple-table: 1.0.0
-  filesize: 6.1.0
   gzip-size: 6.0.0
   libnpmpack: 2.0.0
   meow: 8.0.0
@@ -848,6 +848,12 @@ packages:
     dev: false
     resolution:
       integrity: sha1-y5T662HIaWRR2zZTThQi+U8K7og=
+  /byte-size/7.0.0:
+    dev: false
+    engines:
+      node: '>=10'
+    resolution:
+      integrity: sha512-NNiBxKgxybMBtWdmvx7ZITJi4ZG+CYUgwOSZTfqB1qogkRHrhbQE/R2r5Fh94X+InN5MCYz6SvB/ejHMj/HbsQ==
   /cacache/15.0.5:
     dependencies:
       '@npmcli/move-file': 1.0.1
@@ -2087,12 +2093,6 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==
-  /filesize/6.1.0:
-    dev: false
-    engines:
-      node: '>= 0.4.0'
-    resolution:
-      integrity: sha512-LpCHtPQ3sFx67z+uh2HnSyWSLLu5Jxo21795uRDuar/EOuYWXib5EmPaGIBuSnRqH2IODiKA2k5re/K9OnN/Yg==
   /fill-range/4.0.0:
     dependencies:
       extend-shallow: 2.0.1
@@ -5637,9 +5637,9 @@ packages:
 specifiers:
   '@types/tar': ^4.0.4
   brotli-size: ^4.0.0
+  byte-size: ^7.0.0
   chalk: ^4.1.0
   cli-simple-table: ^1.0.0
-  filesize: ^6.1.0
   gzip-size: ^6.0.0
   husky: ^4.3.0
   libnpmpack: ^2.0.0

--- a/src/pkg-size.ts
+++ b/src/pkg-size.ts
@@ -2,7 +2,6 @@ import path from 'path';
 // @ts-expect-error
 import pack from 'libnpmpack';
 import tar, {ReadEntry} from 'tar';
-import {Readable} from 'stream';
 import gzipSize from 'gzip-size';
 import {stream as brotliSizeStream} from 'brotli-size';
 import {SetRequired} from 'type-fest';
@@ -56,13 +55,13 @@ const getCompressionSizes = async (readEntry: SafeReadEntry): Promise<FileEntry>
 const getTarFiles = async (tarball: Buffer): Promise<FileEntry[]> => new Promise((resolve, reject) => {
 	const promises: Array<Promise<FileEntry>> = [];
 
-	Readable.from(tarball)
-		.pipe(tar.list({}))
+	tar.list({})
 		.on('entry', readEntry => {
 			promises.push(getCompressionSizes(readEntry));
 		})
 		.on('error', error => reject(error))
-		.on('finish', () => resolve(Promise.all(promises)));
+		.on('finish', () => resolve(Promise.all(promises)))
+		.end(tarball);
 });
 
 async function pkgSize(pkgPath = ''): Promise<PkgSizeData> {

--- a/src/pkg-size.ts
+++ b/src/pkg-size.ts
@@ -1,14 +1,13 @@
 import path from 'path';
 // @ts-expect-error
 import pack from 'libnpmpack';
-import tarStream, {Headers} from 'tar-stream';
+import tar, {ReadEntry} from 'tar';
 import {Readable} from 'stream';
-import gunzipMaybe from 'gunzip-maybe';
 import gzipSize from 'gzip-size';
 import {stream as brotliSizeStream} from 'brotli-size';
 import {SetRequired} from 'type-fest';
 
-type FileHeaders = SetRequired<Headers, 'mode' | 'size'>;
+type SafeReadEntry = SetRequired<ReadEntry, 'mode' | 'size'>;
 
 type FileEntry = {
 	path: string;
@@ -24,47 +23,46 @@ type PkgSizeData = {
 	files: FileEntry[];
 };
 
+const getCompressionSizes = async (readEntry: SafeReadEntry): Promise<FileEntry> => new Promise((resolve, reject) => {
+	const file: FileEntry = {
+		/*
+		 * Sanitization from UNPKG:
+		 * https://github.com/mjackson/unpkg/blob/4774e61d50f76c518d0628cfdf8beede5017455d/modules/actions/serveFileMetadata.js#L23
+		 */
+		path: readEntry.path.replace(/^[^/]+\/?/, '/'),
+		mode: readEntry.mode,
+		size: readEntry.size,
+		sizeGzip: Number.NaN,
+		sizeBrotli: Number.NaN,
+	};
+
+	readEntry
+		.pipe(brotliSizeStream())
+		.on('brotli-size', sizeBrotli => {
+			file.sizeBrotli = sizeBrotli;
+		})
+		.pipe(gzipSize.stream())
+		.on('gzip-size', sizeGzip => {
+			file.sizeGzip = sizeGzip;
+		})
+
+		.on('end', () => resolve(file));
+});
+
 /*
  * Based on npm pack logic
  * https://github.com/npm/cli/blob/e9a440bcc5bd9a42dbdbf4bf9340d188c910857c/lib/utils/tar.js
  */
 const getTarFiles = async (tarball: Buffer): Promise<FileEntry[]> => new Promise((resolve, reject) => {
-	const files: FileEntry[] = [];
+	const promises: Array<Promise<FileEntry>> = [];
 
 	Readable.from(tarball)
-		.pipe(gunzipMaybe())
-		.pipe(tarStream.extract())
-		.on('entry', (header: FileHeaders, stream, next) => {
-			const file: FileEntry = {
-				/*
-				 * Sanitization from UNPKG:
-				 * https://github.com/mjackson/unpkg/blob/4774e61d50f76c518d0628cfdf8beede5017455d/modules/actions/serveFileMetadata.js#L23
-				 */
-				path: header.name.replace(/^[^/]+\/?/, '/'),
-				mode: header.mode,
-				size: header.size,
-				sizeGzip: Number.NaN,
-				sizeBrotli: Number.NaN,
-			};
-
-			files.push(file);
-
-			stream = stream
-				.pipe(brotliSizeStream())
-				.on('brotli-size', sizeBrotli => {
-					file.sizeBrotli = sizeBrotli;
-				})
-				.pipe(gzipSize.stream())
-				.on('gzip-size', sizeGzip => {
-					file.sizeGzip = sizeGzip;
-				});
-
-			stream
-				.on('end', next)
-				.resume();
+		.pipe(tar.list({}))
+		.on('entry', readEntry => {
+			promises.push(getCompressionSizes(readEntry));
 		})
 		.on('error', error => reject(error))
-		.on('finish', () => resolve(files));
+		.on('finish', () => resolve(Promise.all(promises)));
 });
 
 async function pkgSize(pkgPath = ''): Promise<PkgSizeData> {


### PR DESCRIPTION
This refactor uses tar (which npm uses) instead of tar-stream.

GitHub Actions seems to be having some errors processing tars via tar-stream:

```
/home/runner/work/pkg-size-action/pkg-size-action/dist/webpack:/pkg-size-action/node_modules/readable-stream/lib/_stream_writable.js:304
    er = new TypeError('Invalid non-string/buffer chunk');
^
TypeError: Invalid non-string/buffer chunk
    at validChunk (/home/runner/work/pkg-size-action/pkg-size-action/dist/webpack:/pkg-size-action/node_modules/readable-stream/lib/_stream_writable.js:304:1)
    at DestroyableTransform.Writable.write (/home/runner/work/pkg-size-action/pkg-size-action/dist/webpack:/pkg-size-action/node_modules/readable-stream/lib/_stream_writable.js:332:1)
    at /home/runner/work/pkg-size-action/pkg-size-action/dist/webpack:/pkg-size-action/node_modules/peek-stream/index.js:63:1
    at /home/runner/work/pkg-size-action/pkg-size-action/dist/webpack:/pkg-size-action/node_modules/gunzip-maybe/index.js:27:1
    at ready (/home/runner/work/pkg-size-action/pkg-size-action/dist/webpack:/pkg-size-action/node_modules/peek-stream/index.js:57:1)
    at DestroyableTransform._transform (/home/runner/work/pkg-size-action/pkg-size-action/dist/webpack:/pkg-size-action/node_modules/peek-stream/index.js:25:1)
    at DestroyableTransform.Transform._read (/home/runner/work/pkg-size-action/pkg-size-action/dist/webpack:/pkg-size-action/node_modules/readable-stream/lib/_stream_transform.js:184:1)
    at DestroyableTransform.Transform._write (/home/runner/work/pkg-size-action/pkg-size-action/dist/webpack:/pkg-size-action/node_modules/readable-stream/lib/_stream_transform.js:172:1)
    at doWrite (/home/runner/work/pkg-size-action/pkg-size-action/dist/webpack:/pkg-size-action/node_modules/readable-stream/lib/_stream_writable.js:428:1)
    at writeOrBuffer (/home/runner/work/pkg-size-action/pkg-size-action/dist/webpack:/pkg-size-action/node_modules/readable-stream/lib/_stream_writable.js:417:1)
```

